### PR TITLE
Update API start docs and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup load run test
+.PHONY: setup load run run-dev test
 
 setup:
 	@echo "Running setup"
@@ -7,7 +7,10 @@ load:
 	@echo "Running load"
 
 run:
-	@echo "Running run"
+        @echo "Running run"
+
+run-dev:
+	poetry run uvicorn api.main:app --reload
 
 test:
 	@echo "Running test"

--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ Asset Insight Graph is a Neo4j‑powered knowledge graph that links real‑estat
 ```
 
 ## Quick Start (Local Dev)
+Docker is optional and may not work in restricted environments.
 ```
 # 1. Clone
 git clone https://github.com/your-org/asset-insight-graph.git
 cd asset-insight-graph
 
-# 2. Spin up Neo4j + API
-docker compose up -d     # default creds: neo4j / neo4j
+# 2. Start Neo4j + API (Docker optional)
+docker compose up -d     # default creds: neo4j / neo4j (may fail in restricted env)
+# or run the API locally (when Docker isn't available):
+poetry run uvicorn api.main:app --reload
+# or via Makefile
+make run-dev
 
 # 3. Ingest sample data
 pip install -r etl/requirements.txt


### PR DESCRIPTION
## Summary
- document how to run the API locally without Docker
- clarify that Docker may not work in restricted environments
- add `run-dev` Makefile target for running uvicorn

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2c30e9a88332afb512d35c0809cb