### PR TITLE
Add async Neo4j connection helper

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -1,0 +1,5 @@
+from neo4j import AsyncGraphDatabase, AsyncDriver
+
+async def get_driver(uri: str, user: str, password: str) -> AsyncDriver:
+    """Create an asynchronous Neo4j driver."""
+    return AsyncGraphDatabase.driver(uri, auth=(user, password))


### PR DESCRIPTION
## Summary
- add `get_driver` helper returning `neo4j.AsyncDriver`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2d4b1b388332b4b2126b5b9e6942