### PR TITLE
Call load_dotenv for API settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ load:
 	@echo "Running load"
 
 run:
-        @echo "Running run"
+	@echo "Running run"
 
 run-dev:
 	poetry run uvicorn api.main:app --reload

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,9 @@
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "neo4j")
+NEO4J_DATABASE = os.getenv("NEO4J_DATABASE", "neo4j")


### PR DESCRIPTION
## Summary
- allow API to read local .env file by calling `load_dotenv()`
- support specifying Neo4j database name with `NEO4J_DATABASE`
- fix `make test` by using a tab

## Testing
- `make test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d30e6a70c8332810f8ee44fa1b36b