### PR TITLE
Add health endpoint test and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+      - name: Run tests
+        run: PYTHONPATH=. pytest -v

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+from api.main import app
+
+class DummyResult:
+    async def single(self):
+        return {"count": 0}
+
+class DummySession:
+    async def run(self, *args, **kwargs):
+        return DummyResult()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummyDriver:
+    def session(self, database=None):
+        return DummySession()
+
+def test_health_endpoint(monkeypatch):
+    monkeypatch.setattr("api.main.get_driver", lambda: DummyDriver())
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add tests directory with a FastAPI test client check of `/health`
- configure GitHub Actions CI to run pytest on pushes and PRs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686def853d9483329b81098a177201d0