### PR TITLE
Fix Neo4j env variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make setup
 
 # 2. Configure environment variables (.env file)
 NEO4J_URI=bolt://localhost:7687
-NEO4J_USER=neo4j
+NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=your_password
 NEO4J_DB=neo4j
 OPENAI_API_KEY=your_openai_key  # Optional for vector search

--- a/api/config.py
+++ b/api/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     """Application settings loaded from environment."""
 
     neo4j_uri: str | None = os.getenv("NEO4J_URI")
-    neo4j_user: str | None = os.getenv("NEO4J_USERNAME")
+    neo4j_user: str | None = os.getenv("NEO4J_USERNAME") or os.getenv("NEO4J_USER")
     neo4j_pwd: str | None = os.getenv("NEO4J_PASSWORD")
     neo4j_db: str = os.getenv("NEO4J_DATABASE", "neo4j")
 
@@ -25,7 +25,7 @@ def get_driver() -> AsyncDriver:
         if not s.neo4j_uri:
             missing.append("NEO4J_URI")
         if not s.neo4j_user:
-            missing.append("NEO4J_USERNAME")
+            missing.append("NEO4J_USERNAME/NEO4J_USER")
         if not s.neo4j_pwd:
             missing.append("NEO4J_PASSWORD")
         raise EnvironmentError(


### PR DESCRIPTION
## Summary
- update docs to use `NEO4J_USERNAME`
- allow `NEO4J_USER` as a fallback in API config

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f40e0907483328aec4cbe9390c815